### PR TITLE
support GBK codepage

### DIFF
--- a/libclocale/libclocale_codepage.c
+++ b/libclocale/libclocale_codepage.c
@@ -311,6 +311,14 @@ int libclocale_codepage_copy_from_string(
 
 				codepage_set = LIBCLOCALE_CODEPAGE_SET_WINDOWS;
 			}
+			else if ( narrow_string_compare_no_case(
+                                string,
+                                "gbk",
+                                3) == 0)
+                        {
+                                *codepage = LIBCLOCALE_CODEPAGE_WINDOWS_936;
+                        }
+
 		}
 	}
 	if( codepage_set == LIBCLOCALE_CODEPAGE_SET_ISO_8859 )


### PR DESCRIPTION
support GBK codepage, The code page CP936 or MS936 has another alias name GBK.