### PR TITLE
Fix use of extern in declarations, following libtool docs

### DIFF
--- a/include/libclocale.h.in
+++ b/include/libclocale.h.in
@@ -57,7 +57,7 @@ int libclocale_initialize(
  * Codepage functions
  * ------------------------------------------------------------------------- */
 
-LIBCLOCALE_EXTERN \
+LIBCLOCALE_EXTERN_VARIABLE \
 int libclocale_codepage;
 
 /* Retrieves the narrow system string codepage

--- a/include/libclocale/extern.h
+++ b/include/libclocale/extern.h
@@ -33,12 +33,14 @@
 #define LIBCLOCALE_EXTERN __declspec(dllexport)
 
 #elif defined( LIBCLOCALE_DLL_IMPORT )
-#define LIBCLOCALE_EXTERN extern __declspec(dllimport)
+#define LIBCLOCALE_EXTERN __declspec(dllimport)
 
 #else
-#define LIBCLOCALE_EXTERN extern
+#define LIBCLOCALE_EXTERN
 
 #endif
+
+#define LIBCLOCALE_EXTERN_VARIABLE extern LIBCLOCALE_EXTERN
 
 #endif /* !defined( _LIBCLOCALE_EXTERN_H ) */
 

--- a/libclocale/libclocale_extern.h
+++ b/libclocale/libclocale_extern.h
@@ -30,14 +30,8 @@
 
 #include <libclocale/extern.h>
 
-#if defined( __CYGWIN__ ) || defined( __MINGW32__ )
-#define LIBCLOCALE_EXTERN_VARIABLE	extern
 #else
-#define LIBCLOCALE_EXTERN_VARIABLE	LIBCLOCALE_EXTERN
-#endif
-
-#else
-#define LIBCLOCALE_EXTERN		/* extern */
+#define LIBCLOCALE_EXTERN
 #define LIBCLOCALE_EXTERN_VARIABLE	extern
 
 #endif /* !defined( HAVE_LOCAL_LIBCLOCALE ) */


### PR DESCRIPTION
This fixes the same problem as https://github.com/libyal/libfmapi/pull/9 for libfmapi and https://github.com/libyal/libcnotify/pull/5 for libcnotify.