### PR TITLE
libclocale_extern.h: fix incorrect macro usage

### DIFF
--- a/libclocale/libclocale_extern.h
+++ b/libclocale/libclocale_extern.h
@@ -24,8 +24,12 @@
 
 #include <common.h>
 
-#if defined( __has_attribute ) && __has_attribute( visibility ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if defined( __has_attribute ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if __has_attribute( visibility )
 #define LIBCLOCALE_INTERNAL	__attribute__((visibility("hidden"))) extern
+#else
+#define LIBCLOCALE_INTERNAL	extern
+#endif
 #else
 #define LIBCLOCALE_INTERNAL	extern
 #endif


### PR DESCRIPTION
@joachimmetz If you could pick this into other libs, it will be helpful. (Or fix it some other way, if this is not suitable.)
See: https://github.com/libyal/libuna/pull/16